### PR TITLE
Fix e-mail addresses for contacts in CLARIN-LT, PolMine configurations

### DIFF
--- a/configuration/CLARIN-LT.cfg
+++ b/configuration/CLARIN-LT.cfg
@@ -5,7 +5,7 @@ define host {
 	 use                            custom-active-host            
 	 display_name                   CLARIN-LT                     
 	 _LAT                           54.9005572                    
-	 contacts                       sysops@clarin.eu,martynas_ore.lt@clarin.eu
+	 contacts                       sysops@clarin.eu,martynas@ore.lt
 	 check_command                  check_dummy                   
 	 _LONG                          23.914398                     
 	 host_name                      CLARIN-LT                     
@@ -33,7 +33,7 @@ define servicegroup {
 
 define service {
 	 use                            custom-active-service,srv-pnp 
-	 contacts                       sysops@clarin.eu,martynas_ore.lt@clarin.eu
+	 contacts                       sysops@clarin.eu,martynas@ore.lt
 	 check_command                  check_oai!https!clarin.vdu.lt!/oai/request!443
 	 servicegroups                  CLARIN-LT_centerregistry      
 	 host_name                      CLARIN-LT                     

--- a/configuration/PolMine.cfg
+++ b/configuration/PolMine.cfg
@@ -5,7 +5,7 @@ define host {
 	 use                            custom-active-host            
 	 display_name                   PolMine Project               
 	 _LAT                           51.4294378                    
-	 contacts                       sysops@clarin.eu,simgeh_posteo.de@clarin.ei
+	 contacts                       sysops@clarin.eu,simgeh@posteo.de
 	 check_command                  check_dummy                   
 	 _LONG                          6.7993325                     
 	 host_name                      PolMine                       
@@ -37,7 +37,7 @@ define servicegroup {
 
 define service {
 	 use                            custom-active-service,srv-pnp 
-	 contacts                       sysops@clarin.eu,simgeh_posteo.de@clarin.ei
+	 contacts                       sysops@clarin.eu,simgeh@posteo.de
 	 check_command                  check_oai!http!polmine.sowi.uni-due.de!/oai/provider!8080
 	 servicegroups                  PolMine_centerregistry        
 	 host_name                      PolMine                       

--- a/configuration/pynag/contacts.cfg
+++ b/configuration/pynag/contacts.cfg
@@ -549,4 +549,15 @@ define contact {
 }
 
 
+define contact {
+	 use                            generic-contact               
+	 email                          martynas@ore.lt
+	 contact_name                   martynas@ore.lt
+}
 
+
+define contact {
+	 use                            generic-contact               
+	 email                          simgeh@posteo.de
+	 contact_name                   simgeh@posteo.de
+}


### PR DESCRIPTION
For some reasons the CLARIN accounts were used as contact addresses in theses (and possible other) cases. Replaced these with the actual e-mail addresses. 