### PR TITLE
Changes FQDN of BBAW/CLARIN repository probe

### DIFF
--- a/conf.d/sites/BBAW.conf
+++ b/conf.d/sites/BBAW.conf
@@ -1,8 +1,8 @@
-object Host "fedora.dwds.de" {
+object Host "clarin.bbaw.de" {
     import "clarin-generic-host"
-    display_name = "fedora.dwds.de"
+    display_name = "clarin.bbaw.de"
     check_command = "ping"
-    address = "fedora.dwds.de"
+    address = "clarin.bbaw.de"
     groups = ["BBAW", "CLARIN"]
 
     vars.geolocation = "52.514156,13.394324"


### PR DESCRIPTION
`http://fedora.dwds.de/` redirects permanently to `https.//clarin.bbaw.de`. This PR updates the HTTP probe accordingly.